### PR TITLE
Fix busybox-initscripts package error in rootfs creation script

### DIFF
--- a/scripts/create-rootfs.sh
+++ b/scripts/create-rootfs.sh
@@ -96,8 +96,7 @@ apk add --no-cache \
     git \
     openssh-client \
     ca-certificates \
-    openrc \
-    busybox-initscripts
+    openrc
 CHROOT_EOF
 
 # 5. Install guest agent


### PR DESCRIPTION
Remove busybox-initscripts from package list as it no longer exists as a separate package in Alpine Linux 3.19. The functionality is now included in the base system and openrc package.